### PR TITLE
Fix bug in previous cards logic

### DIFF
--- a/src/components/GameLogic.jsx
+++ b/src/components/GameLogic.jsx
@@ -97,11 +97,17 @@ const GameLogic = ({ onFinishGame }) => {
     
         setCurrentCard(card);
         setShowBackCard(false);
-        setPreviousCards([...previousCards, card]);
-    
-        if (previousCards.length >= 4) {
-            setPreviousCards(previousCards.slice(1));
-        }
+
+        // Update the list of previously drawn cards while
+        // keeping only the four most recent ones.
+        setPreviousCards(prevCards => {
+            const updatedCards = [...prevCards, card];
+            if (updatedCards.length > 4) {
+                updatedCards.shift();
+            }
+            return updatedCards;
+        });
+
         setPreviousCardValue(card.value);
     
         let isCorrect = false;


### PR DESCRIPTION
## Summary
- preserve newly drawn card when updating previous cards list

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841b3e22a9c83338ead843f184cc726