### PR TITLE
Implement multiplayer replay reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useMultiplayerState } from 'playroomkit';
 import GameLogic from './components/GameLogic';
 import FinishButton from './components/FinishButton';
 import ScorePage from './components/ScorePage';
@@ -14,6 +15,14 @@ function App() {
   const handleReplay = () => {
     setIsGameFinished(false);
   };
+
+  const [restartGame] = useMultiplayerState('restartGame', false);
+
+  useEffect(() => {
+    if (restartGame) {
+      setIsGameFinished(false);
+    }
+  }, [restartGame]);
 
   const BoardGame = () => {
     return (

--- a/src/components/GameLogic.jsx
+++ b/src/components/GameLogic.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Card from '../data/Card';
 import DrinkModal from './DrinkModal';
@@ -23,9 +23,27 @@ const GameLogic = ({ onFinishGame }) => {
     const [activePlayer, setActivePlayer] = useState('');
     const [drinksCount, setDrinksCount] = useState(0);
     const [drinksCountByPlayer, setDrinksCountByPlayer] = useMultiplayerState('drinksCountByPlayer', {});
+    const [restartGame, setRestartGame] = useMultiplayerState('restartGame', false);
     const [, setIsModalOpen] = useState(false);
     const [drinkModal, setDrinkModal] = useState(null); // Ajout de l'état pour la modalité de boisson
     const [isGameFinished] = useMultiplayerState('isGameFinished', false); // Nouvelle variable partagée
+
+    const resetGameState = useCallback(() => {
+        setRound(1);
+        setPreviousCardValue(0);
+        setCurrentCard(null);
+        setShowBackCard(true);
+        setPreviousCards([]);
+        setCurrentPlayerIndex(0);
+        setDrinksCount(0);
+        setDrinksCountByPlayer({});
+        localStorage.removeItem('drinksCountByPlayer');
+        localStorage.removeItem('drinksCount');
+        if (myPlayer().isHost) {
+            setAvailableCards(cardsData);
+            setRestartGame(false);
+        }
+    }, [setRound, setPreviousCardValue, setCurrentCard, setShowBackCard, setPreviousCards, setCurrentPlayerIndex, setDrinksCount, setDrinksCountByPlayer, setAvailableCards, setRestartGame]);
 
     
     useEffect(() => {
@@ -49,7 +67,7 @@ const GameLogic = ({ onFinishGame }) => {
     useEffect(() => {
         const storedDrinksCountByPlayer = JSON.parse(localStorage.getItem('drinksCountByPlayer')) || {};
         setDrinksCountByPlayer(storedDrinksCountByPlayer);
-    }, []);
+    }, [setDrinksCountByPlayer]);
 
     useEffect(() => {
         const storedDrinksCount = parseInt(localStorage.getItem('drinksCount'));
@@ -58,7 +76,7 @@ const GameLogic = ({ onFinishGame }) => {
         } else {
             localStorage.setItem('drinksCount', '0');
         }
-    }, []);
+    }, [setDrinksCount]);
 
     useEffect(() => {
         const currentPlayer = players[currentPlayerIndex];
@@ -77,6 +95,12 @@ const GameLogic = ({ onFinishGame }) => {
 
         waitForEndGame();
     }, []);
+
+    useEffect(() => {
+        if (restartGame) {
+            resetGameState();
+        }
+    }, [restartGame, resetGameState]);
 
     const handleGuess = (guess) => {
         const currentPlayer = players[currentPlayerIndex];

--- a/src/components/ScorePage.jsx
+++ b/src/components/ScorePage.jsx
@@ -17,11 +17,11 @@ const ScorePage = () => {
         setPlayerProfiles(profiles);
     }, [players]);
 
+    const [, setRestartGame] = useMultiplayerState('restartGame', false);
+
     const handleReplay = () => {
         if (isHost) {
-            localStorage.removeItem('drinksCountByPlayer');
-            localStorage.removeItem('drinksCount');
-            window.location.reload();
+            setRestartGame(prev => !prev);
         }
     };
 


### PR DESCRIPTION
## Summary
- allow host to toggle a multiplayer restartGame flag from the score page
- reset all game state when restartGame is triggered
- keep App in sync with restartGame

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841b7afe58083339454043038627a05