### PR TITLE
Fix previous cards rendering check

### DIFF
--- a/src/components/GameLogic.jsx
+++ b/src/components/GameLogic.jsx
@@ -266,11 +266,12 @@ const GameLogic = ({ onFinishGame }) => {
 
             <div className="previous-cards-container">
                 <h3>Previous Cards</h3>
-                {previousCards.map((card, index) => (
-                    <div key={index} className="previous-card">
-                        <Card cardNumber={parseInt(card.value)} color={card.color} />
-                    </div>
-                ))}
+                {Array.isArray(previousCards) &&
+                    previousCards.map((card, index) => (
+                        <div key={index} className="previous-card">
+                            <Card cardNumber={parseInt(card.value)} color={card.color} />
+                        </div>
+                    ))}
 
                 
             </div>


### PR DESCRIPTION
## Summary
- safeguard GameLogic rendering to only map `previousCards` when it's an array

## Testing
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc59878c8333b3d032793f52ab56