### PR TITLE
Update drinks counting

### DIFF
--- a/src/components/GameLogic.jsx
+++ b/src/components/GameLogic.jsx
@@ -21,7 +21,7 @@ const GameLogic = ({ onFinishGame }) => {
     const [availableCards, setAvailableCards] = useState([]);
     const [currentPlayerIndex, setCurrentPlayerIndex] = useMultiplayerState('currentPlayerIndex', 0);
     const [activePlayer, setActivePlayer] = useState('');
-    const [drinksCount, setDrinksCount] = useState(0);
+    const [drinksCount, setDrinksCount] = useMultiplayerState('drinksCount', 0);
     const [drinksCountByPlayer, setDrinksCountByPlayer] = useMultiplayerState('drinksCountByPlayer', {});
     const [, setIsModalOpen] = useState(false);
     const [drinkModal, setDrinkModal] = useState(null); // Ajout de l'état pour la modalité de boisson
@@ -132,6 +132,10 @@ const GameLogic = ({ onFinishGame }) => {
             };
             setDrinksCountByPlayer(newDrinksCountByPlayer);
             localStorage.setItem('drinksCountByPlayer', JSON.stringify(newDrinksCountByPlayer));
+
+            const totalDrinks = drinksCount + 1;
+            setDrinksCount(totalDrinks);
+            localStorage.setItem('drinksCount', totalDrinks.toString());
         }
 
     

--- a/src/components/ScorePage.jsx
+++ b/src/components/ScorePage.jsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { useMultiplayerState, usePlayersList, useIsHost } from 'playroomkit';
 
 const ScorePage = () => {
-    const [drinksCountByPlayer] = useMultiplayerState('drinksCountByPlayer', {});
-    const [drinksCount] = useMultiplayerState('drinksCount', 0);
+    const [drinksCountByPlayer, setDrinksCountByPlayer] = useMultiplayerState('drinksCountByPlayer', {});
+    const [drinksCount, setDrinksCount] = useMultiplayerState('drinksCount', 0);
     const players = usePlayersList();
     const [playerProfiles, setPlayerProfiles] = useState({});
     const isHost = useIsHost();
@@ -21,6 +21,8 @@ const ScorePage = () => {
         if (isHost) {
             localStorage.removeItem('drinksCountByPlayer');
             localStorage.removeItem('drinksCount');
+            setDrinksCountByPlayer({});
+            setDrinksCount(0);
             window.location.reload();
         }
     };


### PR DESCRIPTION
## Summary
- share overall drinksCount state across players
- reset drinks count when replaying

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6841b7b348e8833383cc847720a830fd