### PR TITLE
Auto close drink modal

### DIFF
--- a/src/components/DrinkModal.jsx
+++ b/src/components/DrinkModal.jsx
@@ -1,6 +1,17 @@
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-const DrinkModal = ({ numberOfDrinks, isWinner }) => {
+const DrinkModal = ({ numberOfDrinks, isWinner, onClose }) => {
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            if (onClose) {
+                onClose();
+            }
+        }, 5000);
+
+        return () => clearTimeout(timer);
+    }, [onClose]);
+
     return (
         <div className="modal">
             <div className="modal-content">
@@ -14,6 +25,7 @@ const DrinkModal = ({ numberOfDrinks, isWinner }) => {
 DrinkModal.propTypes = {
     numberOfDrinks: PropTypes.number.isRequired,
     isWinner: PropTypes.bool.isRequired,
+    onClose: PropTypes.func,
 };
 
 export default DrinkModal;

--- a/src/components/GameLogic.jsx
+++ b/src/components/GameLogic.jsx
@@ -262,6 +262,7 @@ const GameLogic = ({ onFinishGame }) => {
                 <DrinkModal
                     numberOfDrinks={drinkModal.numberOfDrinks}
                     isWinner={drinkModal.isWinner}
+                    onClose={() => setDrinkModal(null)}
                 />
             )}
 

--- a/src/components/Pyramid.jsx
+++ b/src/components/Pyramid.jsx
@@ -114,6 +114,7 @@ const Pyramid = ({ previousCards }) => {
                     <DrinkModal
                         numberOfDrinks={drinkModal.numberOfDrinks}
                         isWinner={drinkModal.isWinner}
+                        onClose={() => setDrinkModal(null)}
                     />
                 )}
                 <label>


### PR DESCRIPTION
## Summary
- close `DrinkModal` automatically after 5 seconds
- pass close handlers from `GameLogic` and `Pyramid`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841beaea8fc833393caf26f2ba32cd5